### PR TITLE
fixing scripts errors

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,12 +5,10 @@ BIN_DIR=bin
 
 basic: $(SRC_DIR)/main.cpp
 	mkdir -p $(BIN_DIR)
-	g++ $< -O3 -flto -march=native \
-		-Wall -Werror \
-		-o $(BIN_DIR)/fourier
+	g++ $< -O3 -flto -march=native -Wall -Werror -o $(BIN_DIR)/fourier
 
 run_basic: basic
 	$(BIN_DIR)/fourier
 
 clean:
-	rm -rf bin/
+	rm -rf $(BIN_DIR)

--- a/src/fourier.hpp
+++ b/src/fourier.hpp
@@ -4,9 +4,6 @@
 
 using Complex = std::complex<double>;
 
-/*
-* Basic Naive Discrete Fourier Transform
-*/
 std::vector<Complex> dft(std::vector<Complex>& X) 
 {
     unsigned int N = X.size();
@@ -32,6 +29,10 @@ std::vector<Complex> fft_recurse(std::vector<Complex> X)
 {
     // Length and helper vectors
     const unsigned int N = X.size();
+    if ((N & (N-1)) != 0) {
+        throw std::invalid_argument("Input size is not a power of 2");
+    }
+
     std::vector<Complex> evens(N/2);
     std::vector<Complex> odds(N/2);
 
@@ -65,6 +66,10 @@ std::vector<Complex> fft_iterative_pow_of_2(std::vector<Complex> X)
 {
     // Length
     const unsigned int N = X.size();
+    if ((N & (N-1)) != 0) {
+        throw std::invalid_argument("Input size is not a power of 2");
+    }
+
 
     // Bit-reversal permutation
     unsigned int index_bit_reversed = 0;

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -17,7 +17,7 @@ g++ -O3 -Wall -shared -std=c++17 -fPIC \
     $(python -m pybind11 --includes) \
     -I src/ \
     tests/fourier-bindings.cpp \
-    -o tests/$MODULE_NAME $(python3-config --extension-suffix)
+    -o tests/$MODULE_NAME$(python3-config --extension-suffix)
 
 # Running the test Python file
 pytest tests/


### PR DESCRIPTION
- Exactly as title says `tests/run-tests.sh` have an extra space on output causing errors in testing scripts.
- Added extra power of 2 checks for basic implementation that throws exceptions otherwise.